### PR TITLE
Fix RPC Timestamps

### DIFF
--- a/RockSniffer/RPC/DiscordRPCHandler.cs
+++ b/RockSniffer/RPC/DiscordRPCHandler.cs
@@ -114,7 +114,7 @@ namespace RockSniffer.RPC
                 rp.State = $"by {songdetails.artistName}";
 
                 //Set song timer
-                rp.Timestamps = new Timestamps(DateTime.UtcNow, DateTime.UtcNow.AddSeconds(songdetails.songLength - readout.songTimer));
+                rp.Timestamps = new Timestamps(DateTime.UtcNow.AddSeconds(-readout.songTimer), DateTime.UtcNow.AddSeconds(songdetails.songLength - readout.songTimer));
 
                 //Calculate accuracy
                 float accuracy = readout.noteData.Accuracy;


### PR DESCRIPTION
Currently the formula doesn't calculate the start of the activity correctly, making the time elapsed timer reset on every update.

Before:

![image](https://github.com/user-attachments/assets/ba8fb4e1-6a97-4488-9428-ad3f20a71764)

After:

![image](https://github.com/user-attachments/assets/9a197350-7697-4f83-81d1-15d0f330e507)